### PR TITLE
chore(ci): simplify release ci

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -59,9 +59,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm build
-
       - name: Test
         run: pnpm test
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "format:fix": "oxfmt",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
-    "prepare": "pnpm build",
+    "prepack": "pnpm build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc"


### PR DESCRIPTION
- rename script `prepare` -> `prepack`
  - do not run build when `pnpm install`
- remove `Build` job from release-please.yml