### PR TITLE
feat(diagram-tools): expose created and updated dates in list_diagrams and get_diagram_sheets

### DIFF
--- a/src/tools/get-diagram-sheets.test.ts
+++ b/src/tools/get-diagram-sheets.test.ts
@@ -39,6 +39,8 @@ describe("registerGetDiagramSheetsTool", () => {
         ok({
           diagramId: "diag-1",
           title: "My Diagram",
+          created: "2024-01-01",
+          updated: "2024-06-01",
           sheets: [
             { uid: "sheet-1", name: "Page 1", width: 800, height: 600 },
             { uid: "sheet-2", name: "Page 2", width: 1024, height: 768 },
@@ -51,11 +53,33 @@ describe("registerGetDiagramSheetsTool", () => {
     const result = await getHandler()({ diagramId: "diag-1" });
 
     const text = (result as { content: [{ text: string }] }).content[0]!.text;
+    expect(text).toContain("created: 2024-01-01");
+    expect(text).toContain("updated: 2024-06-01");
     expect(text).toContain("sheetId: sheet-1");
     expect(text).toContain("name: Page 1");
     expect(text).toContain("width: 800");
     expect(text).toContain("height: 600");
     expect(text).toContain("sheetId: sheet-2");
+  });
+
+  it("shows 'unknown' for created and updated when absent", async () => {
+    const { mockServer, getHandler } = captureHandler();
+    const api = createMockApi({
+      getDiagram: vi.fn().mockResolvedValue(
+        ok({
+          diagramId: "diag-1",
+          title: "My Diagram",
+          sheets: [{ uid: "sheet-1", name: "Page 1" }],
+        }),
+      ),
+    });
+    registerGetDiagramSheetsTool(mockServer, api);
+
+    const result = await getHandler()({ diagramId: "diag-1" });
+
+    const text = (result as { content: [{ text: string }] }).content[0]!.text;
+    expect(text).toContain("created: unknown");
+    expect(text).toContain("updated: unknown");
   });
 
   it("returns 'No sheets found' when diagram has no sheets", async () => {

--- a/src/tools/get-diagram-sheets.ts
+++ b/src/tools/get-diagram-sheets.ts
@@ -25,6 +25,8 @@ const formatSheets = (diagram: DiagramDetail): string => {
   return [
     `diagramId: ${diagram.diagramId}`,
     `title: ${diagram.title}`,
+    `created: ${diagram.created ?? "unknown"}`,
+    `updated: ${diagram.updated ?? "unknown"}`,
     "",
     diagram.sheets
       .map((sheet) =>

--- a/src/tools/list-diagrams.test.ts
+++ b/src/tools/list-diagrams.test.ts
@@ -28,6 +28,7 @@ const diagramListResponse = {
       diagramId: "diag-1",
       title: "My Diagram",
       sheetCount: 3,
+      created: "2024-01-01",
       updated: "2024-06-01",
       url: "https://cacoo.com/diagrams/diag-1",
     },
@@ -58,9 +59,29 @@ describe("registerListDiagramsTool", () => {
     expect(text).toContain("diagramId: diag-1");
     expect(text).toContain("title: My Diagram");
     expect(text).toContain("sheetCount: 3");
+    expect(text).toContain("created: 2024-01-01");
     expect(text).toContain("updated: 2024-06-01");
     expect(text).toContain("url: https://cacoo.com/diagrams/diag-1");
     expect(text).toContain("count: 1");
+  });
+
+  it("shows 'unknown' for created and updated when absent", async () => {
+    const { mockServer, getHandler } = captureHandler();
+    const api = createMockApi({
+      getDiagrams: vi.fn().mockResolvedValue(
+        ok({
+          result: [{ diagramId: "diag-1", title: "My Diagram" }],
+          count: 1,
+        }),
+      ),
+    });
+    registerListDiagramsTool(mockServer, api);
+
+    const result = await getHandler()({ offset: 0, limit: 50 });
+
+    const text = (result as { content: [{ text: string }] }).content[0]!.text;
+    expect(text).toContain("created: unknown");
+    expect(text).toContain("updated: unknown");
   });
 
   it("returns 'No diagrams found' when result is empty", async () => {

--- a/src/tools/list-diagrams.ts
+++ b/src/tools/list-diagrams.ts
@@ -28,6 +28,7 @@ const formatDiagram = (diagram: DiagramListResponse["result"][number]): string =
     `diagramId: ${diagram.diagramId}`,
     `title: ${diagram.title}`,
     `sheetCount: ${diagram.sheetCount ?? "unknown"}`,
+    `created: ${diagram.created ?? "unknown"}`,
     `updated: ${diagram.updated ?? "unknown"}`,
     `url: ${diagram.url ?? "unknown"}`,
   ].join("\n");


### PR DESCRIPTION
## Summary

- Add `created` field to `list_diagrams` output (alongside the existing `updated` field)
- Add both `created` and `updated` fields to `get_diagram_sheets` output at the diagram level
- Add test coverage for the `?? "unknown"` fallback path when dates are absent or null

## Details

`created` and `updated` were already defined in `diagramSchema` and fetched from the Cacoo API — only the format functions needed updating. No schema or API client changes required.

`get_diagram_image` is intentionally unchanged: there is no need to mix text metadata into a tool whose output is image content only. Sheet-level dates are also not added since `sheetSchema` has no date fields.

## Test plan

- [x] `list_diagrams` returns `created` and `updated` when present
- [x] `list_diagrams` returns `"unknown"` for `created` and `updated` when absent
- [x] `get_diagram_sheets` returns `created` and `updated` at the diagram level when present
- [x] `get_diagram_sheets` returns `"unknown"` for `created` and `updated` when absent
- [x] All 67 tests pass (`pnpm test`)
- [x] Type check clean (`pnpm typecheck`)
- [x] Lint clean (`pnpm lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)